### PR TITLE
Various necessary changes for Windows

### DIFF
--- a/start_linux.sh
+++ b/start_linux.sh
@@ -13,7 +13,7 @@ esac
 INSTALL_DIR="$(pwd)/installer_files"
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
-MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${OS_ARCH}.sh"
+MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-${OS_ARCH}.sh"
 conda_exists="F"
 
 # figure out whether git and conda needs to be installed
@@ -37,7 +37,7 @@ fi
 
 # create the installer env
 if [ ! -e "$INSTALL_ENV_DIR" ]; then
-    "$CONDA_ROOT_PREFIX/bin/conda" create -y --prefix "$INSTALL_ENV_DIR" python=3.10.9
+    "$CONDA_ROOT_PREFIX/bin/conda" create -y -k --prefix "$INSTALL_ENV_DIR" python=3.10
 fi
 
 # check if conda environment was actually created

--- a/start_macos.sh
+++ b/start_macos.sh
@@ -14,7 +14,7 @@ esac
 INSTALL_DIR="$(pwd)/installer_files"
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
-MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-${OS_ARCH}.sh"
+MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-MacOSX-${OS_ARCH}.sh"
 conda_exists="F"
 
 # figure out whether git and conda needs to be installed
@@ -38,7 +38,7 @@ fi
 
 # create the installer env
 if [ ! -e "$INSTALL_ENV_DIR" ]; then
-    "$CONDA_ROOT_PREFIX/bin/conda" create -y --prefix "$INSTALL_ENV_DIR" python=3.10.9
+    "$CONDA_ROOT_PREFIX/bin/conda" create -y -k --prefix "$INSTALL_ENV_DIR" python=3.10
 fi
 
 # check if conda environment was actually created

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -2,6 +2,8 @@
 
 cd /D "%~dp0"
 
+echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
+
 set PATH=%PATH%;%SystemRoot%\system32
 
 @rem config

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -8,7 +8,7 @@ set PATH=%PATH%;%SystemRoot%\system32
 set INSTALL_DIR=%cd%\installer_files
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
 set INSTALL_ENV_DIR=%cd%\installer_files\env
-set MINICONDA_DOWNLOAD_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
+set MINICONDA_DOWNLOAD_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe
 set conda_exists=F
 
 @rem figure out whether git and conda needs to be installed
@@ -24,7 +24,7 @@ if "%conda_exists%" == "F" (
 	call curl -Lk "%MINICONDA_DOWNLOAD_URL%" > "%INSTALL_DIR%\miniconda_installer.exe" || ( echo. && echo Miniconda failed to download. && goto end )
 
 	echo Installing Miniconda to %CONDA_ROOT_PREFIX%
-	start /wait "" "%INSTALL_DIR%\miniconda_installer.exe" /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /S /D=%CONDA_ROOT_PREFIX%
+	start /wait "" "%INSTALL_DIR%\miniconda_installer.exe" /InstallationType=JustMe /NoShortcuts=1 /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%CONDA_ROOT_PREFIX%
 
 	@rem test the conda binary
 	echo Miniconda version:
@@ -34,7 +34,7 @@ if "%conda_exists%" == "F" (
 @rem create the installer env
 if not exist "%INSTALL_ENV_DIR%" (
   echo Packages to install: %PACKAGES_TO_INSTALL%
-  call "%CONDA_ROOT_PREFIX%\_conda.exe" create -y --prefix "%INSTALL_ENV_DIR%" python=3.10.9 || ( echo. && echo Conda environment creation failed. && goto end )
+  call "%CONDA_ROOT_PREFIX%\_conda.exe" create --no-shortcuts -y -k --prefix "%INSTALL_ENV_DIR%" python=3.10 || ( echo. && echo Conda environment creation failed. && goto end )
 )
 
 @rem check if conda environment was actually created

--- a/webui.py
+++ b/webui.py
@@ -49,12 +49,12 @@ def install_dependencies():
 
     # Install the version of PyTorch needed
     if gpuchoice == "a":
-        run_cmd("conda install -y pytorch[version=2,build=py3.10_cuda11.7*] torchvision torchaudio pytorch-cuda=11.7 cuda-toolkit ninja git -c pytorch -c nvidia/label/cuda-11.7.0 -c nvidia")
+        run_cmd("conda install -y -k pytorch[version=2,build=py3.10_cuda11.7*] torchvision torchaudio pytorch-cuda=11.7 cuda-toolkit ninja git -c pytorch -c nvidia/label/cuda-11.7.0 -c nvidia")
     elif gpuchoice == "b":
         print("AMD GPUs are not supported. Exiting...")
         sys.exit()
     elif gpuchoice == "c" or gpuchoice == "d":
-        run_cmd("conda install -y pytorch torchvision torchaudio cpuonly git -c pytorch")
+        run_cmd("conda install -y -k pytorch torchvision torchaudio cpuonly git -c pytorch")
     else:
         print("Invalid choice. Exiting...")
         sys.exit()
@@ -63,7 +63,7 @@ def install_dependencies():
     run_cmd("git clone https://github.com/oobabooga/text-generation-webui.git")
     if sys.platform.startswith("win"):
         # Fix a bitsandbytes compatibility issue with Windows
-        run_cmd("python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.37.2-py3-none-any.whl")
+        run_cmd("python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.38.1-py3-none-any.whl")
     
     # Install the remaining webui dependencies
     update_dependencies()


### PR DESCRIPTION
- Change Miniconda installer to fixed version.
- Add necessary flags to Miniconda installer
- Disable Start Menu shortcut creation
- Disable ssl on Conda
- Change Python version to latest 3.10
I've noticed that explicitly specifying 3.10.9 can break the Python installation included with Miniconda

+ Update bitsandbytes wheel link to 0.38.1